### PR TITLE
Add summary endpoint and read-time estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ bun run dev
 ```
 
 open http://localhost:3000
+
+## Summary Endpoint
+
+You can retrieve a short summary and estimated read time for any article URL using:
+
+```sh
+curl "http://localhost:3000/summary?url=<ARTICLE_URL>"
+```
+
+The response contains `summary` and `read_time` fields.

--- a/src/estimateReadTime.ts
+++ b/src/estimateReadTime.ts
@@ -1,0 +1,7 @@
+const estimateReadTime = (text: string): string => {
+  const words = text.trim().split(/\s+/).length;
+  const minutes = Math.max(1, Math.ceil(words / 200));
+  return `${minutes} min`;
+};
+
+export default estimateReadTime;

--- a/src/getArticles.ts
+++ b/src/getArticles.ts
@@ -2,6 +2,8 @@ import { config } from "dotenv";
 config({
     path: "../.env",
 });
+import extractArticleText from "./extractArticleText";
+import estimateReadTime from "./estimateReadTime";
 
 const apiKey = process.env.GOOGLE_SEARCH_KEY;
 const cxKey = process.env.GOOGLE_CX_KEY;
@@ -12,15 +14,17 @@ const getArticles = async (searchParam: string) => {
     const response = await fetch(queryUrl)
         .then((response) => response.json())
         .then((res) => res);
-    let cleanedLinks = [];
+    let cleanedLinks = [] as Array<{title: string; displayLink: string; link: string; read_time: string}>;
     if (response.items) {
         for (let i = 0; i < response.items.length; i++) {
             let entry = response.items[i];
+            const text = await extractArticleText(entry.link);
+            const readTime = estimateReadTime(text);
             cleanedLinks.push({
                 title: entry.title,
                 displayLink: entry.displayLink,
                 link: entry.link,
-                read_time: "0 min",
+                read_time: readTime,
             });
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import { Hono } from "hono";
 import { logger } from "hono/logger";
 import { cors } from "hono/cors";
 import driver from "./driver";
+import extractArticleText from "./extractArticleText";
+import summarizeArticle from "./summarizeArticle";
+import estimateReadTime from "./estimateReadTime";
 
 const app = new Hono();
 
@@ -19,6 +22,17 @@ app.get("/", async (c) => {
         return c.json({
             error: "error",
         });
+});
+
+app.get("/summary", async (c) => {
+    const url = c.req.query("url");
+    if (!url) {
+        return c.json({ error: "error" });
+    }
+    const text = await extractArticleText(url);
+    const summary = await summarizeArticle(text);
+    const read_time = estimateReadTime(text);
+    return c.json({ summary, read_time });
 });
 
 app.fire();

--- a/src/summarizeArticle.ts
+++ b/src/summarizeArticle.ts
@@ -1,0 +1,28 @@
+import OpenAI from "openai";
+import { config } from "dotenv";
+config({ path: "../.env" });
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const summarizeArticle = async (text: string): Promise<string> => {
+  if (!text) return "";
+  try {
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4-turbo",
+      messages: [
+        {
+          role: "user",
+          content: `Summarize the following article in three sentences:\n${text}`,
+        },
+      ],
+      temperature: 0.7,
+      max_tokens: 150,
+    });
+    return completion.choices[0].message.content?.trim() || "";
+  } catch (error) {
+    console.error(error);
+    return "";
+  }
+};
+
+export default summarizeArticle;


### PR DESCRIPTION
## Summary
- calculate read time from article text
- generate article summaries via OpenAI
- expose new `/summary` endpoint
- compute read time for Google search results
- document summary endpoint

## Testing
- `bun install`
- `npx tsc --noEmit` *(fails: interface mismatches in bun types)*

------
https://chatgpt.com/codex/tasks/task_e_6887b8c0b59483208e566afb436f763f